### PR TITLE
Accessing pre-filtered nbgitpuller logs from BigQuery

### DIFF
--- a/notebooks/nbgitpuller_processing_visualization.ipynb
+++ b/notebooks/nbgitpuller_processing_visualization.ipynb
@@ -159,10 +159,31 @@
     }
    ],
    "source": [
-    "# opens up the nbgitpuller file - uses gzip to open so need to ensure that file is zipped\n",
-    "nbgitpuller_filename = '../spring-2023/nbgitpuller-clicks-spring-2023.json.gz'\n",
-    "nbgitpuller_df = pd.read_json(gzip.open(nbgitpuller_filename), lines = True)\n",
-    "nbgitpuller_df.head()"
+    "%pip install google-cloud-bigquery\n",
+    "%pip install pandas-gbq\n",
+    "\n",
+    "# Authenticate to GCP in the shell, like this:\n",
+    "# gcloud auth application-default login\n",
+    "\n",
+    "from google.cloud import bigquery\n",
+    "from pandas.io import gbq\n",
+    "\n",
+    "# Set up BigQuery client\n",
+    "project_id = 'ucb-datahub-2018'\n",
+    "client = bigquery.Client(project=project_id)\n",
+    "\n",
+    "# Define SQL query\n",
+    "# replace the FROM... with the BigQuery table you want to query\n",
+    "query = \"\"\"\n",
+    "SELECT *\n",
+    "FROM `ucb-datahub-2018.datahub_su24.stderr_*`\n",
+    "\"\"\"\n",
+    "\n",
+    "# Execute query and load data into DataFrame\n",
+    "nbgitpuller_df = gbq.read_gbq(query, project_id=project_id)\n",
+    "\n",
+    "nbgitpuller_df.head()\n",
+    "\n"
    ]
   },
   {


### PR DESCRIPTION
This approach accesses pre-filtered nbgitpuller-related logs from GCP BigQuery. This depends on a Log Router Sink streaming filtered nbgitpuller logs in real time; Log Router Sink is *not* a query!

Note that the FROM... part of the Big Query SQL must match the source data you want to use.